### PR TITLE
Refactor H264Payloader to allow the deactivation of STAP-A packets.  …

### DIFF
--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -12,6 +12,11 @@ import (
 // H264Payloader payloads H264 packets.
 type H264Payloader struct {
 	spsNalu, ppsNalu []byte
+	disableStapA     bool
+}
+
+func (p *H264Payloader) disableStapAPackets() {
+	p.disableStapA = true
 }
 
 const (
@@ -84,14 +89,16 @@ func (p *H264Payloader) Payload(mtu uint16, payload []byte) [][]byte { //nolint:
 		case naluType == audNALUType || naluType == fillerNALUType:
 			return
 		case naluType == spsNALUType:
-			p.spsNalu = nalu
-
-			return
+			if !p.disableStapA {
+				p.spsNalu = nalu
+				return
+			}
 		case naluType == ppsNALUType:
-			p.ppsNalu = nalu
-
-			return
-		case p.spsNalu != nil && p.ppsNalu != nil:
+			if !p.disableStapA {
+				p.ppsNalu = nalu
+				return
+			}
+		case !p.disableStapA && p.spsNalu != nil && p.ppsNalu != nil:
 			// Pack current NALU with SPS and PPS as STAP-A
 			spsLen := make([]byte, 2)
 			binary.BigEndian.PutUint16(spsLen, uint16(len(p.spsNalu))) // nolint: gosec // G115

--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -303,3 +303,29 @@ func TestH264Payloader_Payload_SPS_and_PPS_handling(t *testing.T) {
 		t.Fatal("SPS and PPS aren't packed together")
 	}
 }
+
+func TestH264Payloader_Payload_SPS_and_PPS_handling_no_stapA(t *testing.T) {
+	pck := H264Payloader{}
+	pck.disableStapAPackets()
+
+	expectedSps := []byte{0x07, 0x00, 0x01}
+	// The SPS is packed as a single NALU
+	res := pck.Payload(1500, expectedSps)
+	if len(res) != 1 {
+		t.Fatal("Generated payload should not be empty")
+	}
+	if !reflect.DeepEqual(res[0], expectedSps) {
+		t.Fatal("SPS has not been packed correctly")
+	}
+	// The PPS is packed as a single NALU
+	expectedPps := []byte{0x08, 0x02, 0x03}
+	res = pck.Payload(1500, expectedPps)
+	if len(res) != 1 {
+		t.Fatal("Generated payload should not be empty")
+	}
+
+	if !reflect.DeepEqual(res[0], expectedPps) {
+		t.Fatal("PPS has not been packed correctly")
+	}
+
+}


### PR DESCRIPTION
…NALUs of type 7 (SPS) and type 8 (PPS) will be packed as Single NAL Units if STAP-A are disabled.

This change can  help to support packetization-mode=0 (single NALUs) in compliance with RFC6184.